### PR TITLE
Fix to chiliproject issue 908

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -287,7 +287,9 @@ class Issue < ActiveRecord::Base
 
     # Bug #501: browsers might swap the line endings causing a Journal.
     if attrs.has_key?('description') && attrs['description'].present?
-      if attrs['description'].gsub(/\r\n?/,"\n") == self.description
+      new_description = attrs['description'].gsub("\n","").gsub("\r","")
+      old_description = self.description.gsub("\n","").gsub("\r","")
+      if (new_description == old_description)
         attrs.delete('description')
       end
     end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -288,7 +288,10 @@ class Issue < ActiveRecord::Base
     # Bug #501: browsers might swap the line endings causing a Journal.
     if attrs.has_key?('description') && attrs['description'].present?
       new_description = attrs['description'].gsub("\n","").gsub("\r","")
-      old_description = self.description.gsub("\n","").gsub("\r","")
+      old_description = self.description
+      if (!old_description.nil?)
+        old_description = old_description.gsub("\n","").gsub("\r","")
+      end
       if (new_description == old_description)
         attrs.delete('description')
       end

--- a/test/unit/issue_test.rb
+++ b/test/unit/issue_test.rb
@@ -895,4 +895,21 @@ class IssueTest < ActiveSupport::TestCase
     assert_equal "Description with newlines\n\nembedded", issue.reload.description
   end
 
+
+  test 'changing the line endings and carry returns in a description will not be recorded as a Journal' do
+    User.current = User.find(1)
+    issue = Issue.find(1)
+    issue.update_attribute(:description, "Description with newlines\r\r\n\r\r\nembedded")
+    issue.reload
+    assert issue.description.include?("\n")
+
+    assert_no_difference("Journal.count") do
+      issue.safe_attributes= {
+          'description' => "Description with newlines\r\n\r\n\r\n\r\nembedded"
+      }
+      assert issue.save
+    end
+
+    assert_equal "Description with newlines\r\r\n\r\r\nembedded", issue.reload.description
+  end
 end


### PR DESCRIPTION
When issues are update different browsers handle line breaks in different ways and in some cases this situation generates changes in the description field. This pull-request handles this situation by removing line breaks and carry return characters.
